### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 ## v0.3.0
 
 * Switched from `config.yaml` to `config.schema.yaml`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Integration pack that provides support for Trello, an online Task Tracking tool
 Copy the example configuration in [trello.yaml.example](./trello.yaml.example)
 to `/opt/stackstorm/configs/trello.yaml` and edit as required.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ### Action Configuration
 
 For actions, the configuration should contain:

--- a/actions/add_board.yaml
+++ b/actions/add_board.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_board
-runner_type: "run-python"
+runner_type: "python-script"
 description: Create a new board
 enabled: true
 entry_point: "add_board.py"

--- a/actions/add_card.yaml
+++ b/actions/add_card.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_card
-runner_type: "run-python"
+runner_type: "python-script"
 description: Add a new card to a list
 enabled: true
 entry_point: "add_card.py"

--- a/actions/add_list.yaml
+++ b/actions/add_list.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_list
-runner_type: "run-python"
+runner_type: "python-script"
 description: Add a new list to a board
 enabled: true
 entry_point: "add_list.py"

--- a/actions/close_board.yaml
+++ b/actions/close_board.yaml
@@ -1,6 +1,6 @@
 ---
 name: close_board
-runner_type: "run-python"
+runner_type: "python-script"
 description: Close a board
 enabled: true
 entry_point: "close_board.py"

--- a/actions/close_card.yaml
+++ b/actions/close_card.yaml
@@ -1,6 +1,6 @@
 ---
 name: close_card
-runner_type: "run-python"
+runner_type: "python-script"
 description: Close a card
 enabled: true
 entry_point: "close_card.py"

--- a/actions/close_list.yaml
+++ b/actions/close_list.yaml
@@ -1,6 +1,6 @@
 ---
 name: close_list
-runner_type: "run-python"
+runner_type: "python-script"
 description: Close a list belonging to a board
 enabled: true
 entry_point: "close_list.py"

--- a/actions/find_board_by_name.yaml
+++ b/actions/find_board_by_name.yaml
@@ -1,6 +1,6 @@
 ---
 name: find_board_by_name
-runner_type: "run-python"
+runner_type: "python-script"
 description: Lookup a board ID based on name. Returns one or more IDs
 enabled: true
 entry_point: "find_board_by_name.py"

--- a/actions/find_card_by_name.yaml
+++ b/actions/find_card_by_name.yaml
@@ -1,6 +1,6 @@
 ---
 name: find_card_by_name
-runner_type: "run-python"
+runner_type: "python-script"
 description: Lookup a Card ID based on name. Returns one or more IDs
 enabled: true
 entry_point: "find_card_by_name.py"

--- a/actions/find_list_by_name.yaml
+++ b/actions/find_list_by_name.yaml
@@ -1,6 +1,6 @@
 ---
 name: find_list_by_name
-runner_type: "run-python"
+runner_type: "python-script"
 description: Lookup a list ID based on name. Returns one or more IDs
 enabled: true
 entry_point: "find_list_by_name.py"

--- a/actions/move_card.yaml
+++ b/actions/move_card.yaml
@@ -1,6 +1,6 @@
 ---
 name: move_card
-runner_type: "run-python"
+runner_type: "python-script"
 description: Move a card from one board/list to another board/list
 enabled: true
 entry_point: "move_card.py"

--- a/actions/view_boards.yaml
+++ b/actions/view_boards.yaml
@@ -1,6 +1,6 @@
 ---
 name: view_boards
-runner_type: "run-python"
+runner_type: "python-script"
 description: Return a dictionary of all boards and their IDs
 enabled: true
 entry_point: "view_boards.py"

--- a/actions/view_cards.yaml
+++ b/actions/view_cards.yaml
@@ -1,6 +1,6 @@
 ---
 name: view_cards
-runner_type: "run-python"
+runner_type: "python-script"
 description: View all cards on a board
 enabled: true
 entry_point: "view_cards.py"

--- a/actions/view_lists.yaml
+++ b/actions/view_lists.yaml
@@ -1,6 +1,6 @@
 ---
 name: view_lists
-runner_type: "run-python"
+runner_type: "python-script"
 description: View all lists belonging to a board
 enabled: true
 entry_point: "view_lists.py"

--- a/actions/view_organizations.yaml
+++ b/actions/view_organizations.yaml
@@ -1,6 +1,6 @@
 ---
 name: view_organizations
-runner_type: "run-python"
+runner_type: "python-script"
 description: List all organizations for user
 enabled: true
 entry_point: "view_organizations.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: trello
 name: trello
 description: Integration with Trello, Web based Project Management
-version: 0.3.0
+version: 0.4.0
 author: James Fryman
 email: james@stackstorm.com
 keywords:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.